### PR TITLE
Add FilletMiddleTop fillet strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 </p>
 
 <p align="center">
-  <img 
-      src="assets/img/cover.png" 
-      style="max-width: 480px; width: 80%" 
+  <img
+      src="assets/img/cover.png"
+      style="max-width: 480px; width: 80%"
       alt="Rendered keycap model created with Capistry"
   />
 </p>
@@ -161,16 +161,19 @@ cap = RectangularCap(taper=taper)
 ### Fillet Strategies
 Choose how edges are rounded:
 ```python
-# Uniform filleting
-fillet_strat = FilletUniform()
+# Uniform
+strat = FilletUniform()
 
-# Sides-first filleting
-fillet_strat = FilletSidesFirst()
+# Front-to-back, then left-to-right
+strat = FilletDepthWidth()
 
-# Sides-Last filleting
-fillet_strat = FilletSidesFirst()
+# Left-to-right, then front-to-back
+strat = FilletWidthDepth()
 
-cap = RectangularCap(fillet_strategy=fillet_strat)
+# Mid-height edges, then top-perimeter
+strat = FilletMiddleTop()
+
+cap = RectangularCap(fillet_strategy=strat)
 ```
 
 > [!WARNING]
@@ -214,8 +217,8 @@ cap = RectangularCap()
 
 # Create a 4x4 panel of a keycap
 panel = Panel(
-    items=[PanelItem(cap, quantity=16)], 
-    sprue=SprueCylinder(), 
+    items=[PanelItem(cap, quantity=16)],
+    sprue=SprueCylinder(),
     cols=4
 )
 

--- a/examples/filleting/main.py
+++ b/examples/filleting/main.py
@@ -38,20 +38,28 @@ c1 = RectangularCap(
     roof=roof,
     taper=taper,
     stem=stem,
-    fillet_strategy=FilletUniform(),
+    fillet_strategy=FilletUniform(),  # Uniform fillet, every outside edge gets the same radius
 )
 
+# Fillet left-to-right, then front-to-back
 c2 = c1.clone()
-c2.fillet_strategy = FilletSidesFirst()
+c2.fillet_strategy = FilletWidthDepth()
 c2.build()
 c2.locate(c1.top_right * Pos(X=gap))
 
+# Fillet front-to-back, then left-to-right
 c3 = c1.clone()
-c3.fillet_strategy = FilletSidesLast()
+c3.fillet_strategy = FilletDepthWidth()
 c3.build()
 c3.locate(c2.top_right * Pos(X=gap))
 
-caps = [c1.compound, c2.compound, c3.compound]
+# Fillet middle edges first, then top perimeter
+c4 = c1.clone()
+c4.fillet_strategy = FilletMiddleTop()
+c4.build()
+c4.locate(c3.top_right * Pos(X=gap))
+
+caps = [c1.compound, c2.compound, c3.compound, c4.compound]
 
 show(*caps)
 

--- a/src/capistry/__init__.py
+++ b/src/capistry/__init__.py
@@ -1,15 +1,16 @@
 """
 .. include:: ../../README.md
-"""
+"""  # noqa: D200, D400
 
 from .cap import Cap, RectangularCap, SkewedCap, SlantedCap, TrapezoidCap
 from .compare import BaseComparer, Comparer
 from .ergogen import Ergogen, ErgogenSchema
 from .fillet import (
-    FilletSidesFirst,
-    FilletSidesLast,
+    FilletDepthWidth,
+    FilletMiddleTop,
     FilletStrategy,
     FilletUniform,
+    FilletWidthDepth,
     fillet_safe,
 )
 from .logger import init_logger
@@ -20,29 +21,30 @@ from .surface import Surface
 from .taper import Taper
 
 __all__ = [
+    "BaseComparer",
     "Cap",
+    "ChocStem",
+    "Comparer",
+    "Ergogen",
+    "ErgogenSchema",
+    "FilletDepthWidth",
+    "FilletMiddleTop",
+    "FilletStrategy",
+    "FilletUniform",
+    "FilletWidthDepth",
+    "MXStem",
+    "Panel",
+    "PanelItem",
     "RectangularCap",
     "SkewedCap",
     "SlantedCap",
-    "TrapezoidCap",
-    "FilletSidesFirst",
-    "FilletSidesLast",
-    "FilletStrategy",
-    "FilletUniform",
-    "fillet_safe",
-    "Panel",
-    "PanelItem",
-    "Comparer",
-    "BaseComparer",
-    "ChocStem",
-    "MXStem",
-    "Stem",
-    "Surface",
-    "Taper",
-    "init_logger",
     "Sprue",
     "SprueCylinder",
     "SpruePolygon",
-    "Ergogen",
-    "ErgogenSchema",
+    "Stem",
+    "Surface",
+    "Taper",
+    "TrapezoidCap",
+    "fillet_safe",
+    "init_logger",
 ]


### PR DESCRIPTION
 -  Added `FilletMiddleTop` fillet strategy
    - Fillets vertical/slanted mid-height edges first, then top face perimeter
- Renamed `FilletSidesFirst` to `FilletWidthDepth`
- Renamed `FilletSidesLast` to `FilletDepthWidth`
